### PR TITLE
Refactor the scanToken method to ignore whitespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+.idea


### PR DESCRIPTION
This changes the return value from `Result<Token>` to `Result<Option<Token>>`,
and ignores whitespace. If we wanted to start lexing whitespace again, we'd
just have to change the `None` to `Some(self.make_token(TokenType::Ws, ...)`